### PR TITLE
Use absolute path as aliases for reference docs

### DIFF
--- a/docs/reference/hostfacts/hostfacts.md
+++ b/docs/reference/hostfacts/hostfacts.md
@@ -12,7 +12,7 @@ section_menu_id: reference
 menu_name: product_searchlight_8.0.0-rc.0
 url: /products/searchlight/8.0.0-rc.0/reference/hostfacts/
 aliases:
-  - products/searchlight/8.0.0-rc.0/reference/hostfacts/hostfacts/
+  - /products/searchlight/8.0.0-rc.0/reference/hostfacts/hostfacts/
 
 ---
 ## hostfacts

--- a/docs/reference/hyperalert/hyperalert.md
+++ b/docs/reference/hyperalert/hyperalert.md
@@ -12,7 +12,7 @@ section_menu_id: reference
 menu_name: product_searchlight_8.0.0-rc.0
 url: /products/searchlight/8.0.0-rc.0/reference/hyperalert/
 aliases:
-  - products/searchlight/8.0.0-rc.0/reference/hyperalert/hyperalert/
+  - /products/searchlight/8.0.0-rc.0/reference/hyperalert/hyperalert/
 
 ---
 ## hyperalert

--- a/docs/reference/searchlight/searchlight.md
+++ b/docs/reference/searchlight/searchlight.md
@@ -12,7 +12,7 @@ section_menu_id: reference
 menu_name: product_searchlight_8.0.0-rc.0
 url: /products/searchlight/8.0.0-rc.0/reference/searchlight/
 aliases:
-  - products/searchlight/8.0.0-rc.0/reference/searchlight/searchlight/
+  - /products/searchlight/8.0.0-rc.0/reference/searchlight/searchlight/
 
 ---
 ## searchlight

--- a/hack/gendocs/main.go
+++ b/hack/gendocs/main.go
@@ -58,7 +58,7 @@ menu_name: product_searchlight_{{ .Version }}
 {{- if .RootCmd }}
 url: /products/searchlight/{{ .Version }}/reference/hostfacts/
 aliases:
-  - products/searchlight/{{ .Version }}/reference/hostfacts/hostfacts/
+  - /products/searchlight/{{ .Version }}/reference/hostfacts/hostfacts/
 {{ end }}
 ---
 `))
@@ -151,7 +151,7 @@ menu_name: product_searchlight_{{ .Version }}
 {{- if .RootCmd }}
 url: /products/searchlight/{{ .Version }}/reference/hyperalert/
 aliases:
-  - products/searchlight/{{ .Version }}/reference/hyperalert/hyperalert/
+  - /products/searchlight/{{ .Version }}/reference/hyperalert/hyperalert/
 {{ end }}
 ---
 `))
@@ -244,7 +244,7 @@ menu_name: product_searchlight_{{ .Version }}
 {{- if .RootCmd }}
 url: /products/searchlight/{{ .Version }}/reference/searchlight/
 aliases:
-  - products/searchlight/{{ .Version }}/reference/searchlight/searchlight/
+  - /products/searchlight/{{ .Version }}/reference/searchlight/searchlight/
 {{ end }}
 ---
 `))


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>